### PR TITLE
Add vanish_requests stream subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "assertables"
 version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +717,20 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1965,6 +1985,7 @@ dependencies = [
  "nostr-sdk",
  "ordermap",
  "pretty_assertions",
+ "redis",
  "rustls",
  "serde",
  "serde_json",
@@ -2654,6 +2675,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.27.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6baebe319ef5e4b470f248335620098d1c2e9261e995be05f56f719ca4bdb2"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "ryu",
+ "sha1_smol",
+ "socket2",
+ "tokio",
+ "tokio-retry2",
+ "tokio-rustls",
+ "tokio-util",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,6 +3139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,6 +3432,17 @@ name = "tokio-retry"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project 1.1.5",
+ "rand",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry2"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903934dba1c4c2f2e9cb460ef10b5695e0b0ecad3bf9ee7c8675e540c5e8b2d1"
 dependencies = [
  "pin-project 1.1.5",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ neo4rs = "0.8.0"
 nonzero_ext = "0.3.0"
 nostr-sdk = "0.33.0"
 ordermap = "0.5.3"
+redis = { version = "0.27.4", features = ["connection-manager", "tls-rustls", "tls-rustls-webpki-roots", "tokio-rustls-comp"] }
 rustls = { version = "0.23.12", features = ["ring"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.128"

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,10 +5,6 @@ services:
       context: .
       target: final
     environment:
-      - APP__followers__relay=ws://relay:7777
-      - APP__followers__neo4j_uri=db:7687
-      - APP__followers__neo4j_user=neo4j
-      - APP__followers__neo4j_password=mydevpassword
       - APP__ENVIRONMENT=development
       - GOOGLE_APPLICATION_CREDENTIALS=/app/gcloud/application_default_credentials.json
       - RUST_LOG=nos_followers=debug

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ pub struct Settings {
     pub pagerank_cron_expression: String,
     pub http_cache_seconds: u32,
     pub burst: NonZeroU16,
+    pub redis_url: String,
 }
 
 impl Configurable for Settings {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,5 @@ pub mod relay_subscriber;
 pub mod repo;
 pub mod scheduler;
 pub mod tcp_importer;
+pub mod vanish_subscriber;
 pub mod worker_pool;

--- a/src/vanish_subscriber.rs
+++ b/src/vanish_subscriber.rs
@@ -1,0 +1,172 @@
+use crate::repo::RepoTrait;
+use async_trait::async_trait;
+use nostr_sdk::prelude::PublicKey;
+use redis::{
+    aio::ConnectionManager,
+    streams::{StreamKey, StreamReadOptions, StreamReadReply},
+    AsyncCommands, RedisError,
+};
+use std::error::Error;
+use std::sync::Arc;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tracing::{error, info};
+
+static BLOCK_MILLIS: usize = 5000;
+static VANISH_STREAM_KEY: &str = "vanish_requests";
+static VANISH_LAST_ID_KEY: &str = "vanish_requests:followers_subscriber:last_id";
+
+pub struct RedisClient {
+    client: redis::Client,
+}
+
+#[async_trait]
+pub trait RedisClientTrait: Send + Sync + 'static {
+    type Connection: RedisClientConnectionTrait;
+    async fn get_connection(&self) -> Result<Self::Connection, RedisError>;
+}
+
+impl RedisClient {
+    pub fn new(url: &str) -> Self {
+        let client = redis::Client::open(url).expect("Failed to create Redis client");
+        RedisClient { client }
+    }
+}
+
+#[async_trait]
+impl RedisClientTrait for RedisClient {
+    type Connection = RedisClientConnection;
+    async fn get_connection(&self) -> Result<Self::Connection, RedisError> {
+        let con = self.client.get_connection_manager().await?;
+        Ok(RedisClientConnection { con })
+    }
+}
+
+pub struct RedisClientConnection {
+    con: ConnectionManager,
+}
+
+#[async_trait]
+pub trait RedisClientConnectionTrait: Send + Sync + 'static {
+    async fn get(&mut self, key: &str) -> Result<String, RedisError>;
+    async fn set(&mut self, key: &str, value: String) -> Result<(), RedisError>;
+    async fn xread_options(
+        &mut self,
+        keys: &[&str],
+        ids: &[String],
+        opts: &StreamReadOptions,
+    ) -> Result<StreamReadReply, RedisError>;
+}
+
+#[async_trait]
+impl RedisClientConnectionTrait for RedisClientConnection {
+    async fn get(&mut self, key: &str) -> Result<String, RedisError> {
+        match self.con.get(key).await {
+            Ok(value) => Ok(value),
+            Err(_) => self.con.get(key).await,
+        }
+    }
+
+    async fn set(&mut self, key: &str, value: String) -> Result<(), RedisError> {
+        match self.con.set(key, value.clone()).await {
+            Ok(()) => Ok(()),
+            Err(_) => self.con.set(key, value).await,
+        }
+    }
+
+    async fn xread_options(
+        &mut self,
+        keys: &[&str],
+        ids: &[String],
+        opts: &StreamReadOptions,
+    ) -> Result<StreamReadReply, RedisError> {
+        match self.con.xread_options(keys, ids, opts).await {
+            Ok(reply) => Ok(reply),
+            Err(_) => self.con.xread_options(keys, ids, opts).await,
+        }
+    }
+}
+
+pub fn start_vanish_subscriber<T: RedisClientTrait, U: RepoTrait>(
+    tracker: TaskTracker,
+    redis_client: T,
+    repo: Arc<U>,
+    cancellation_token: CancellationToken,
+) {
+    tracker.spawn(async move {
+        let (mut con, mut last_id) = match get_connection_and_last_id(redis_client).await {
+            Ok(result) => result,
+            Err(e) => {
+                error!("Failed to get Redis connection: {}", e);
+                return;
+            }
+        };
+
+        let opts = StreamReadOptions::default().block(BLOCK_MILLIS);
+
+        info!("Starting from last id processed: {}", last_id);
+
+        loop {
+            tokio::select! {
+                _ = cancellation_token.cancelled() => {
+                    break;
+                }
+
+                result = async {
+                    let reply: StreamReadReply = con
+                        .xread_options(&[VANISH_STREAM_KEY], &[last_id.clone()], &opts)
+                        .await?;
+
+                    for StreamKey { ids, .. } in reply.keys {
+                        for stream_id in ids {
+                            if stream_id.id == last_id {
+                                continue;
+                            }
+
+                            let Some(value) = stream_id.map.get("pubkey") else {
+                                error!("Vanish request doesn't have a public key");
+                                continue;
+                            };
+
+                            let public_key = match value {
+                                redis::Value::BulkString(bytes) => {
+                                    let public_key_string = String::from_utf8(bytes.clone())?;
+
+                                    PublicKey::from_hex(public_key_string)?
+                                }
+                                _ => {
+                                    error!("Vanish request public key is not a bulk string");
+                                    continue;
+                                }
+                            };
+
+                            if let Err(e) = repo.remove_pubkey(&public_key).await {
+                                error!("Failed to remove public key: {}", e);
+                            }
+
+                            info!("Removed public key {} from vanish request", public_key.to_hex());
+
+                            last_id = stream_id.id.clone();
+                        }
+                    }
+                    Ok::<(), Box<dyn Error>>(())
+                } => {
+                    if let Err(e) = result {
+                        error!("Error in Redis stream reader task: {}", e);
+                        continue;
+                    }
+                }
+            }
+        }
+    });
+}
+
+async fn get_connection_and_last_id<T: RedisClientTrait>(
+    redis_client: T,
+) -> Result<(T::Connection, String), RedisError> {
+    let mut con = redis_client.get_connection().await?;
+    let last_id = con
+        .get(&VANISH_LAST_ID_KEY)
+        .await
+        .unwrap_or_else(|_| "0-0".to_string());
+    Ok((con, last_id))
+}


### PR DESCRIPTION
This is part of https://github.com/planetary-social/infrastructure/issues/139

Subscribes to the vanish_subscriber stream so we can drop pubkey nodes and their relationships. It also updates the cached counters.

Notice we still would need to add some state to all the subscribers of this stream to avoid accepting republications. We can always restart the processing of the vanish requests from the beginning periodically as a quick cleanup but this will need to be implemented at another moment to be able to hit the deadline.

This was manually tested sucessfully, with more time I'd like to add some tests.